### PR TITLE
Do-notation for Effects.

### DIFF
--- a/docs/source/api/effect.do.rst
+++ b/docs/source/api/effect.do.rst
@@ -1,0 +1,7 @@
+effect.do module
+================
+
+.. automodule:: effect.do
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/api/effect.rst
+++ b/docs/source/api/effect.rst
@@ -6,6 +6,7 @@ Submodules
 
 .. toctree::
 
+   effect.do
    effect.retry
    effect.testing
    effect.twisted

--- a/effect/do.py
+++ b/effect/do.py
@@ -1,0 +1,72 @@
+from __future__ import print_function
+
+import types
+
+from . import Effect, Constant
+
+
+def do(f):
+    """
+    A decorator which allows you to use ``do`` notation in your functions, for
+    imperative-looking code::
+
+        @do
+        def foo():
+            thing = yield Effect(Constant(1))
+            yield do_return('the result was %r' % (thing,))
+
+        eff = foo()
+        return eff.on(...)
+
+    ``@do`` must decorate a generator function. Any yielded values must either
+    be Effects or the result of a :func:`do_return` call. The result of a
+    yielded Effect will be passed back into the generator as the result of the
+    ``yield`` expression. Yielded :func:`do_return` values will provide the
+    ultimate result of the Effect that is returned by the decorated function.
+
+    It's important to note that any generator function decorated by ``@do``
+    will no longer return a generator, but instead it will return an Effect,
+    which must be used just like any other Effect.
+
+    Errors are also converted to normal exceptions:
+
+        @do
+        def foo():
+            try:
+                thing = yield Effect(Error(RuntimeError('foo')))
+            except RuntimeError:
+                yield do_return('got a RuntimeError as expected')
+    """
+    def inner(*args, **kwargs):
+        gen = f(*args, **kwargs)
+        if not isinstance(gen, types.GeneratorType):
+            raise TypeError(
+                "%r is not a generator function. It returned %r." % (f, gen))
+        return Effect(Constant(None)).on(lambda r: _do(r, gen, False))
+    return inner
+
+
+_return_sentinel = object()
+
+
+def do_return(val):
+    return (_return_sentinel, val)
+
+
+def _do(result, generator, is_error):
+    try:
+        if is_error:
+            val = generator.throw(*result)
+        else:
+            val = generator.send(result)
+    except StopIteration:
+        return None
+    if type(val) is tuple and val[0] is _return_sentinel:
+        return val[1]
+    elif type(val) is Effect:
+        return val.on(success=lambda r: _do(r, generator, False),
+                      error=lambda e: _do(e, generator, True))
+    else:
+        raise TypeError(
+            "@do functions must only yield Effects or results of do_return. "
+            "Got %r" % (val,))

--- a/effect/do.py
+++ b/effect/do.py
@@ -1,3 +1,10 @@
+"""
+An imperative-looking notation for Effectful code.
+
+See :func:`do`.
+"""
+
+
 from __future__ import print_function
 
 import types
@@ -28,7 +35,7 @@ def do(f):
     will no longer return a generator, but instead it will return an Effect,
     which must be used just like any other Effect.
 
-    Errors are also converted to normal exceptions:
+    Errors are also converted to normal exceptions::
 
         @do
         def foo():
@@ -36,6 +43,9 @@ def do(f):
                 thing = yield Effect(Error(RuntimeError('foo')))
             except RuntimeError:
                 yield do_return('got a RuntimeError as expected')
+
+    (This decorator is named for Haskell's ``do`` notation, which is similar in
+    spirit).
     """
     def inner(*args, **kwargs):
         gen = f(*args, **kwargs)

--- a/effect/do.py
+++ b/effect/do.py
@@ -10,6 +10,7 @@ from __future__ import print_function
 import types
 
 from . import Effect, Constant
+from ._utils import wraps
 
 
 def do(f):
@@ -47,13 +48,14 @@ def do(f):
     (This decorator is named for Haskell's ``do`` notation, which is similar in
     spirit).
     """
-    def inner(*args, **kwargs):
+    @wraps(f)
+    def do_wrapper(*args, **kwargs):
         gen = f(*args, **kwargs)
         if not isinstance(gen, types.GeneratorType):
             raise TypeError(
                 "%r is not a generator function. It returned %r." % (f, gen))
         return Effect(Constant(None)).on(lambda r: _do(r, gen, False))
-    return inner
+    return do_wrapper
 
 
 class _ReturnSentinel(object):

--- a/effect/do.py
+++ b/effect/do.py
@@ -9,7 +9,7 @@ from __future__ import print_function
 
 import types
 
-from . import Effect, Constant
+from . import Effect, Func
 from ._utils import wraps
 
 
@@ -50,11 +50,16 @@ def do(f):
     """
     @wraps(f)
     def do_wrapper(*args, **kwargs):
-        gen = f(*args, **kwargs)
-        if not isinstance(gen, types.GeneratorType):
-            raise TypeError(
-                "%r is not a generator function. It returned %r." % (f, gen))
-        return Effect(Constant(None)).on(lambda r: _do(r, gen, False))
+
+        def doit():
+            gen = f(*args, **kwargs)
+            if not isinstance(gen, types.GeneratorType):
+                raise TypeError(
+                    "%r is not a generator function. It returned %r."
+                    % (f, gen))
+            return _do(None, gen, False)
+
+        return Effect(Func(doit))
     return do_wrapper
 
 

--- a/effect/test_do.py
+++ b/effect/test_do.py
@@ -20,7 +20,7 @@ class DoTests(TestCase):
         """When do is passed a non-generator function, it raises an error."""
         f = lambda: None
         self.assertThat(
-            do(f),
+            lambda: perf(do(f)()),
             raises(TypeError(
                 "%r is not a generator function. It returned None." % (f,)
             )))
@@ -121,3 +121,15 @@ class DoTests(TestCase):
         original.attr = 1
         wrapped = do(new_func)
         self.assertEqual(wrapped.__name__, 'do_wrapper')
+
+    def test_repeatable_effect(self):
+        """
+        The Effect returned by the call to the @do function is repeatable.
+        """
+        @do
+        def f():
+            x = yield Effect(Constant('foo'))
+            yield do_return(x)
+        eff = f()
+        self.assertEqual(perf(eff), 'foo')
+        self.assertEqual(perf(eff), 'foo')

--- a/effect/test_do.py
+++ b/effect/test_do.py
@@ -52,8 +52,9 @@ class DoTests(TestCase):
         @do
         def f():
             yield 1
+        result = f()
         self.assertThat(
-            lambda: perf(f()),
+            lambda: perf(result),
             raises(TypeError(
                 "@do functions must only yield Effects or results of "
                 "do_return. Got 1")))

--- a/effect/test_do.py
+++ b/effect/test_do.py
@@ -1,0 +1,76 @@
+import sys
+
+from testtools import TestCase
+from testtools.matchers import raises, MatchesException
+
+from . import Constant, Effect, Error, base_dispatcher, sync_perform
+from .do import do, do_return
+
+
+def perf(e):
+    return sync_perform(base_dispatcher, e)
+
+
+class DoTests(TestCase):
+
+    def test_do_non_gf(self):
+        """When do is passed a non-generator function, it raises an error."""
+        f = lambda: None
+        self.assertThat(
+            do(f),
+            raises(TypeError(
+                "%r is not a generator function. It returned None." % (f,)
+            )))
+
+    def test_do_return(self):
+        """
+        When a @do function yields a do_return, the given value becomes the
+        eventual result.
+        """
+        @do
+        def f():
+            yield do_return("hello")
+        self.assertEqual(perf(f()), "hello")
+
+    def test_yield_effect(self):
+        """Yielding an effect in @do results in the Effect's result."""
+        @do
+        def f():
+            x = yield Effect(Constant(3))
+            yield do_return(x)
+        self.assertEqual(perf(f()), 3)
+
+    def test_fall_off_the_end(self):
+        """Falling off the end results in None."""
+        @do
+        def f():
+            yield Effect(Constant(3))
+        self.assertEqual(perf(f()), None)
+
+    def test_yield_non_effect(self):
+        """Yielding a non-Effect results in a TypeError."""
+        @do
+        def f():
+            yield 1
+        self.assertThat(
+            lambda: perf(f()),
+            raises(TypeError(
+                "@do functions must only yield Effects or results of "
+                "do_return. Got 1")))
+
+    def test_raise_from_effect(self):
+        """
+        If an Effect results in an error, it will be raised as a synchronous
+        exception in the generator.
+        """
+        @do
+        def f():
+            try:
+                yield Effect(Error(ZeroDivisionError('foo')))
+            except:
+                got_error = sys.exc_info()
+            yield do_return(got_error)
+
+        self.assertThat(
+            perf(f()),
+            MatchesException(ZeroDivisionError('foo')))


### PR DESCRIPTION
This adds a `@do` decorator, that allows you to use Effects in a way similar to Twisted's `inlineCallbacks` or Haskell's `do`.