### PR TITLE
Generic asynchronous parallel performer

### DIFF
--- a/effect/__init__.py
+++ b/effect/__init__.py
@@ -13,7 +13,7 @@ from ._base import Effect, perform, NoPerformerFoundError
 from ._sync import NotSynchronousError, sync_perform, sync_performer
 from ._intents import (
     Delay, ParallelEffects, parallel,
-    Constant, Error, Func,
+    Constant, Error, FirstError, Func,
     base_dispatcher)
 from ._dispatcher import ComposedDispatcher, TypeDispatcher
 
@@ -22,7 +22,7 @@ __all__ = [
     "Effect", "perform", "NoPerformerFoundError",
     "NotSynchronousError", "sync_perform", "sync_performer",
     "Delay", "ParallelEffects", "parallel",
-    "Constant", "Error", "Func",
+    "Constant", "Error", "FirstError", "Func",
     "base_dispatcher",
     "TypeDispatcher", "ComposedDispatcher",
 ]

--- a/effect/_intents.py
+++ b/effect/_intents.py
@@ -31,6 +31,12 @@ class ParallelEffects(object):
 
     :func:`effect.async.perform_parallel_async` can perform this Intent
     assuming all child effects have asynchronous performers.
+
+    Note that any performer for this intent will need to be compatible with
+    performers for all of its child effects' intents. Notably, if child effects
+    have blocking performers, it's useless to use
+    :func:`effect.async.perform_parallel_async`, and if they're asynchronous,
+    it's useless to perform them with a threaded performer.
     """
     def __init__(self, effects):
         """

--- a/effect/_intents.py
+++ b/effect/_intents.py
@@ -18,6 +18,7 @@ Twisted-specific dispatcher for these.
 from __future__ import print_function, absolute_import
 from characteristic import attributes, Attribute
 from functools import partial
+from itertools import count
 
 from ._base import Effect, perform
 from ._sync import sync_performer
@@ -30,12 +31,8 @@ class ParallelEffects(object):
     An effect intent that asks for a number of effects to be run in parallel,
     and for their results to be gathered up into a sequence.
 
-    Performers for this intent could perform the child effects in threads, or
-    use some other concurrency mechanism like Twisted's ``gatherResults``. Of
-    course, the implementation strategy for this effect will need to cooperate
-    with the performers of the Effects being parallelized -- e.g., a
-    ``@deferred_performer`` performer for a child intent should not be used
-    with a thread-dispatching performer for :class:`ParallelEffects`.
+    :func:`perform_parallel_async` can perform this Intent assuming all child
+    effects have asynchronous performers.
     """
     def __init__(self, effects):
         """
@@ -55,58 +52,48 @@ def parallel(effects):
     return Effect(ParallelEffects(list(effects)))
 
 
-@attributes(['failure', 'index'])
+@attributes(['exception', 'index'])
 class FirstError(Exception):
-    pass
+    """
+    One of the effects in a :obj:`ParallelEffects` resulted in an error. This
+    represents the first such error that occurred.
+    """
+    def __str__(self):
+        return '(index=%s) %s: %s' % (
+            self.index, type(self.exception).__name__, self.exception)
 
 
-@attributes([
-    Attribute('count'),
-    Attribute('box'),
-    Attribute('results', exclude_from_init=True),
-    Attribute('finished', exclude_from_init=True),
-])
-class _ParallelHelper(object):
+def perform_parallel_async(dispatcher, intent, box):
+    """
+    A performer for :obj:`ParallelEffects` which works if all child Effects are
+    intrinsically asynchronous. Use this for things like Twisted, asyncio, etc.
 
-    def __init__(self):
-        self.results = [None] * self.count
-        self.finished = 0
-
-    def succeed(self, result, index):
-        self.finished += 1
-        if self.box is None:
-            return
-
-        self.results[index] = result
-        if self.finished == self.count:
-            box, self.box = self.box, None
-            box.succeed(self.results)
-
-    def fail(self, result, index):
-        self.finished += 1
-        if self.box is None:
-            return
-
-        box, self.box = self.box, None
-        box.fail(
-            (FirstError, FirstError(failure=result, index=index), result[2]))
-
-
-def perform_parallel(dispatcher, intent, box):
+    WARNING: If this is used when child Effects have blocking performers, it
+    will run them in serial, not parallel.
+    """
     effects = list(intent.effects)
-
     if not effects:
         box.succeed([])
         return
+    num_results = count()
+    results = [None] * len(effects)
 
-    helper = _ParallelHelper(count=len(effects), box=box)
+    def succeed(index, result):
+        results[index] = result
+        if next(num_results) + 1 == len(effects):
+            box.succeed(results)
+
+    def fail(index, result):
+        box.fail((FirstError,
+                  FirstError(exception=result[1], index=index),
+                  result[2]))
 
     for index, effect in enumerate(effects):
         perform(
             dispatcher,
             effect.on(
-                success=partial(helper.succeed, index=index),
-                error=partial(helper.fail, index=index)))
+                success=partial(succeed, index),
+                error=partial(fail, index)))
 
 
 @attributes(['delay'], apply_with_init=False, apply_immutable=True)

--- a/effect/_intents.py
+++ b/effect/_intents.py
@@ -16,7 +16,7 @@ Twisted-specific dispatcher for these.
 
 
 from __future__ import print_function, absolute_import
-from characteristic import attributes, Attribute
+from characteristic import attributes
 from functools import partial
 from itertools import count
 

--- a/effect/_test_utils.py
+++ b/effect/_test_utils.py
@@ -1,0 +1,40 @@
+"""Another sad little utility module."""
+
+import traceback
+
+from characteristic import attributes
+
+from testtools.matchers import Equals
+
+
+@attributes(['expected_tb', 'got_tb'])
+class ReraisedTracebackMismatch(object):
+    def describe(self):
+        return ("The reference traceback:\n"
+                + ''.join(self.expected_tb)
+                + "\nshould match the tail end of the received traceback:\n"
+                + ''.join(self.got_tb)
+                + "\nbut it doesn't.")
+
+
+@attributes(['expected'], apply_with_init=False)
+class MatchesReraisedExcInfo(object):
+
+    def __init__(self, expected):
+        self.expected = expected
+
+    def match(self, actual):
+        valcheck = Equals(self.expected[1]).match(actual[1])
+        if valcheck is not None:
+            print "val doesn't match", valcheck
+            return valcheck
+        typecheck = Equals(self.expected[0]).match(actual[0])
+        if typecheck is not None:
+            print "type doesn't match", typecheck
+            return typecheck
+        expected = traceback.format_exception(*self.expected)
+        new = traceback.format_exception(*actual)
+        tail_equals = lambda a, b: a == b[-len(a):]
+        if not tail_equals(expected[1:], new[1:]):
+            return ReraisedTracebackMismatch(expected_tb=expected,
+                                             got_tb=new)

--- a/effect/_test_utils.py
+++ b/effect/_test_utils.py
@@ -26,11 +26,9 @@ class MatchesReraisedExcInfo(object):
     def match(self, actual):
         valcheck = Equals(self.expected[1]).match(actual[1])
         if valcheck is not None:
-            print "val doesn't match", valcheck
             return valcheck
         typecheck = Equals(self.expected[0]).match(actual[0])
         if typecheck is not None:
-            print "type doesn't match", typecheck
             return typecheck
         expected = traceback.format_exception(*self.expected)
         new = traceback.format_exception(*actual)

--- a/effect/async.py
+++ b/effect/async.py
@@ -38,5 +38,3 @@ def perform_parallel_async(dispatcher, intent, box):
             effect.on(
                 success=partial(succeed, index),
                 error=partial(fail, index)))
-
-

--- a/effect/async.py
+++ b/effect/async.py
@@ -29,7 +29,7 @@ def perform_parallel_async(dispatcher, intent, box):
 
     def fail(index, result):
         box.fail((FirstError,
-                  FirstError(exception=result[1], index=index),
+                  FirstError(exc_info=result, index=index),
                   result[2]))
 
     for index, effect in enumerate(effects):

--- a/effect/async.py
+++ b/effect/async.py
@@ -1,0 +1,42 @@
+"""Generic asynchronous performers."""
+
+from functools import partial
+from itertools import count
+
+from ._base import perform
+from ._intents import FirstError
+
+
+def perform_parallel_async(dispatcher, intent, box):
+    """
+    A performer for :obj:`ParallelEffects` which works if all child Effects are
+    already asynchronous. Use this for things like Twisted, asyncio, etc.
+
+    WARNING: If this is used when child Effects have blocking performers, it
+    will run them in serial, not parallel.
+    """
+    effects = list(intent.effects)
+    if not effects:
+        box.succeed([])
+        return
+    num_results = count()
+    results = [None] * len(effects)
+
+    def succeed(index, result):
+        results[index] = result
+        if next(num_results) + 1 == len(effects):
+            box.succeed(results)
+
+    def fail(index, result):
+        box.fail((FirstError,
+                  FirstError(exception=result[1], index=index),
+                  result[2]))
+
+    for index, effect in enumerate(effects):
+        perform(
+            dispatcher,
+            effect.on(
+                success=partial(succeed, index),
+                error=partial(fail, index)))
+
+

--- a/effect/test_async.py
+++ b/effect/test_async.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 
-from testtools.matchers import raises
 from testtools.testcase import TestCase
 
 from characteristic import attributes
@@ -13,10 +12,10 @@ from ._sync import sync_perform
 from .async import perform_parallel_async
 from .test_base import func_dispatcher
 
+
 @attributes(['message'])
 class EquitableException(Exception):
     pass
-
 
 
 class PerformParallelAsyncTests(TestCase):
@@ -65,8 +64,8 @@ class PerformParallelAsyncTests(TestCase):
 
     def test_error_index(self):
         """
-        The ``index`` of a :obj:`FirstError` is the index of the effect that failed
-        in the list.
+        The ``index`` of a :obj:`FirstError` is the index of the effect that
+        failed in the list.
         """
         try:
             sync_perform(

--- a/effect/test_async.py
+++ b/effect/test_async.py
@@ -53,12 +53,33 @@ class PerformParallelAsyncTests(TestCase):
         When given an effect that results in a Error,
         ``perform_parallel_async`` result in ``FirstError``.
         """
-        self.assertThat(
-            lambda: sync_perform(
+        try:
+            sync_perform(
                 self.dispatcher,
-                parallel([Effect(Error(EquitableException(message="foo")))])),
-            raises(FirstError(exception=EquitableException(message='foo'),
-                              index=0)))
+                parallel([Effect(Error(EquitableException(message="foo")))]))
+        except FirstError as fe:
+            self.assertEqual(
+                fe,
+                FirstError(exception=EquitableException(message='foo'),
+                           index=0))
+
+    def test_error_index(self):
+        """
+        The ``index`` of a :obj:`FirstError` is the index of the effect that failed
+        in the list.
+        """
+        try:
+            sync_perform(
+                self.dispatcher,
+                parallel([
+                    Effect(Constant(1)),
+                    Effect(Error(EquitableException(message="foo"))),
+                    Effect(Constant(2))]))
+        except FirstError as fe:
+            self.assertEqual(
+                fe,
+                FirstError(exception=EquitableException(message='foo'),
+                           index=1))
 
     def test_out_of_order(self):
         """

--- a/effect/test_async.py
+++ b/effect/test_async.py
@@ -1,0 +1,84 @@
+from __future__ import print_function
+
+from testtools.matchers import raises
+from testtools.testcase import TestCase
+
+from characteristic import attributes
+
+from ._base import Effect, perform
+from ._dispatcher import ComposedDispatcher, TypeDispatcher
+from ._intents import (
+    Constant, Error, FirstError, ParallelEffects, parallel, base_dispatcher)
+from ._sync import sync_perform
+from .async import perform_parallel_async
+from .test_base import func_dispatcher
+
+@attributes(['message'])
+class EquitableException(Exception):
+    pass
+
+
+
+class PerformParallelAsyncTests(TestCase):
+
+    def setUp(self):
+        super(PerformParallelAsyncTests, self).setUp()
+        self.dispatcher = ComposedDispatcher([
+            base_dispatcher,
+            TypeDispatcher({ParallelEffects: perform_parallel_async})])
+
+    def test_empty(self):
+        """
+        When given an empty list of effects, ``perform_parallel_async`` returns
+        an empty list synchronusly.
+        """
+        result = sync_perform(
+            self.dispatcher,
+            parallel([]))
+        self.assertEqual(result, [])
+
+    def test_parallel(self):
+        """
+        'parallel' results in a list of results of the given effects, in the
+        same order that they were passed to parallel.
+        """
+        result = sync_perform(
+            self.dispatcher,
+            parallel([Effect(Constant('a')),
+                      Effect(Constant('b'))]))
+        self.assertEqual(result, ['a', 'b'])
+
+    def test_error(self):
+        """
+        When given an effect that results in a Error,
+        ``perform_parallel_async`` result in ``FirstError``.
+        """
+        self.assertThat(
+            lambda: sync_perform(
+                self.dispatcher,
+                parallel([Effect(Error(EquitableException(message="foo")))])),
+            raises(FirstError(exception=EquitableException(message='foo'),
+                              index=0)))
+
+    def test_out_of_order(self):
+        """
+        The result order corresponds to the order of the effects as passed to
+        :obj:`ParallelEffects` even when the results become available in a
+        different order.
+        """
+        result = []
+        boxes = [None] * 2
+        eff = parallel([
+            Effect(lambda box: boxes.__setitem__(0, box)),
+            Effect(lambda box: boxes.__setitem__(1, box)),
+        ])
+        perform(
+            ComposedDispatcher([
+                TypeDispatcher({ParallelEffects: perform_parallel_async}),
+                func_dispatcher,
+            ]),
+            eff.on(success=result.append, error=print))
+        boxes[1].succeed('a')
+        self.assertEqual(result, [])
+        boxes[0].succeed('b')
+        self.assertEqual(result[0], ['b', 'a'])

--- a/effect/test_intents.py
+++ b/effect/test_intents.py
@@ -1,8 +1,9 @@
 from __future__ import print_function, absolute_import
 
+from characteristic import attributes
+
 from testtools import TestCase
-from testtools.matchers import (
-    Raises, MatchesStructure, MatchesException, Equals)
+from testtools.matchers import raises
 
 from ._base import Effect, perform
 from ._sync import sync_perform
@@ -12,11 +13,16 @@ from ._intents import (
     Constant, perform_constant,
     Error, perform_error,
     Func, perform_func,
-    ParallelEffects, perform_parallel, parallel, FirstError,
+    ParallelEffects, perform_parallel_async, parallel, FirstError,
 )
 
 
 from .test_base import func_dispatcher
+
+
+@attributes(['message'])
+class EquibleException(Exception):
+    pass
 
 
 class IntentTests(TestCase):
@@ -59,11 +65,11 @@ class ParallelTests(TestCase):
 
     def test_empty(self):
         """
-        When given an empty list of effects, ``perform_parallel`` returns
+        When given an empty list of effects, ``perform_parallel_async`` returns
         an empty list synchronusly.
         """
         result = sync_perform(
-            TypeDispatcher({ParallelEffects: perform_parallel}),
+            TypeDispatcher({ParallelEffects: perform_parallel_async}),
             parallel([]))
         self.assertEqual(result, [])
 
@@ -73,7 +79,7 @@ class ParallelTests(TestCase):
         same order that they were passed to parallel.
         """
         result = sync_perform(
-            TypeDispatcher({ParallelEffects: perform_parallel,
+            TypeDispatcher({ParallelEffects: perform_parallel_async,
                             Constant: perform_constant}),
             parallel([Effect(Constant('a')),
                       Effect(Constant('b'))]))
@@ -81,34 +87,42 @@ class ParallelTests(TestCase):
 
     def test_error(self):
         """
-        When given an effect that results in a Error, ``perform_parallel``
+        When given an effect that results in a Error, ``perform_parallel_async``
         result in ``FirstError``.
         """
         self.assertThat(
             lambda: sync_perform(
-                TypeDispatcher({ParallelEffects: perform_parallel,
+                TypeDispatcher({ParallelEffects: perform_parallel_async,
                                 Error: perform_error}),
-                parallel([Effect(Error(ValueError("foo")))])),
-            Raises(
-                MatchesException(
-                    FirstError,
-                    MatchesStructure(
-                        failure=MatchesException(ValueError('foo')),
-                        index=Equals(0)))))
+                parallel([Effect(Error(EquibleException(message="foo")))])),
+            raises(FirstError(exception=EquibleException(message='foo'),
+                              index=0)))
 
     def test_out_of_order(self):
+        """
+        The result order corresponds to the order of the effects as passed to
+        :obj:`ParallelEffects` even when the results become available in a
+        different order.
+        """
         result = []
-        boxes = [None]*2
+        boxes = [None] * 2
         eff = parallel([
             Effect(lambda box: boxes.__setitem__(0, box)),
             Effect(lambda box: boxes.__setitem__(1, box)),
             ])
         perform(
             ComposedDispatcher([
-                TypeDispatcher({ParallelEffects: perform_parallel}),
+                TypeDispatcher({ParallelEffects: perform_parallel_async}),
                 func_dispatcher]),
             eff.on(success=result.append, error=print))
         boxes[1].succeed('a')
         self.assertEqual(result, [])
         boxes[0].succeed('b')
         self.assertEqual(result[0], ['b', 'a'])
+
+    def test_first_error_str(self):
+        """FirstErrors have a pleasing format."""
+        fe = FirstError(exception=ValueError('foo'), index=150)
+        self.assertEqual(
+            str(fe),
+            '(index=150) ValueError: foo')

--- a/effect/test_intents.py
+++ b/effect/test_intents.py
@@ -51,7 +51,6 @@ class IntentTests(TestCase):
 class ParallelTests(TestCase):
     """Tests for :func:`parallel`."""
 
-
     def test_first_error_str(self):
         """FirstErrors have a pleasing format."""
         fe = FirstError(exception=ValueError('foo'), index=150)

--- a/effect/test_intents.py
+++ b/effect/test_intents.py
@@ -53,7 +53,8 @@ class ParallelTests(TestCase):
 
     def test_first_error_str(self):
         """FirstErrors have a pleasing format."""
-        fe = FirstError(exception=ValueError('foo'), index=150)
+        fe = FirstError(exc_info=(ValueError, ValueError('foo'), None),
+                        index=150)
         self.assertEqual(
             str(fe),
             '(index=150) ValueError: foo')

--- a/effect/test_intents.py
+++ b/effect/test_intents.py
@@ -87,8 +87,8 @@ class ParallelTests(TestCase):
 
     def test_error(self):
         """
-        When given an effect that results in a Error, ``perform_parallel_async``
-        result in ``FirstError``.
+        When given an effect that results in a Error,
+        ``perform_parallel_async`` result in ``FirstError``.
         """
         self.assertThat(
             lambda: sync_perform(
@@ -109,7 +109,7 @@ class ParallelTests(TestCase):
         eff = parallel([
             Effect(lambda box: boxes.__setitem__(0, box)),
             Effect(lambda box: boxes.__setitem__(1, box)),
-            ])
+        ])
         perform(
             ComposedDispatcher([
                 TypeDispatcher({ParallelEffects: perform_parallel_async}),

--- a/effect/test_intents.py
+++ b/effect/test_intents.py
@@ -1,28 +1,16 @@
 from __future__ import print_function, absolute_import
 
-from characteristic import attributes
-
 from testtools import TestCase
-from testtools.matchers import raises
 
-from ._base import Effect, perform
+from ._base import Effect
 from ._sync import sync_perform
-from ._dispatcher import TypeDispatcher, ComposedDispatcher
+from ._dispatcher import TypeDispatcher
 
 from ._intents import (
     Constant, perform_constant,
     Error, perform_error,
     Func, perform_func,
-    ParallelEffects, perform_parallel_async, parallel, FirstError,
-)
-
-
-from .test_base import func_dispatcher
-
-
-@attributes(['message'])
-class EquibleException(Exception):
-    pass
+    FirstError)
 
 
 class IntentTests(TestCase):
@@ -63,62 +51,6 @@ class IntentTests(TestCase):
 class ParallelTests(TestCase):
     """Tests for :func:`parallel`."""
 
-    def test_empty(self):
-        """
-        When given an empty list of effects, ``perform_parallel_async`` returns
-        an empty list synchronusly.
-        """
-        result = sync_perform(
-            TypeDispatcher({ParallelEffects: perform_parallel_async}),
-            parallel([]))
-        self.assertEqual(result, [])
-
-    def test_parallel(self):
-        """
-        'parallel' results in a list of results of the given effects, in the
-        same order that they were passed to parallel.
-        """
-        result = sync_perform(
-            TypeDispatcher({ParallelEffects: perform_parallel_async,
-                            Constant: perform_constant}),
-            parallel([Effect(Constant('a')),
-                      Effect(Constant('b'))]))
-        self.assertEqual(result, ['a', 'b'])
-
-    def test_error(self):
-        """
-        When given an effect that results in a Error,
-        ``perform_parallel_async`` result in ``FirstError``.
-        """
-        self.assertThat(
-            lambda: sync_perform(
-                TypeDispatcher({ParallelEffects: perform_parallel_async,
-                                Error: perform_error}),
-                parallel([Effect(Error(EquibleException(message="foo")))])),
-            raises(FirstError(exception=EquibleException(message='foo'),
-                              index=0)))
-
-    def test_out_of_order(self):
-        """
-        The result order corresponds to the order of the effects as passed to
-        :obj:`ParallelEffects` even when the results become available in a
-        different order.
-        """
-        result = []
-        boxes = [None] * 2
-        eff = parallel([
-            Effect(lambda box: boxes.__setitem__(0, box)),
-            Effect(lambda box: boxes.__setitem__(1, box)),
-        ])
-        perform(
-            ComposedDispatcher([
-                TypeDispatcher({ParallelEffects: perform_parallel_async}),
-                func_dispatcher]),
-            eff.on(success=result.append, error=print))
-        boxes[1].succeed('a')
-        self.assertEqual(result, [])
-        boxes[0].succeed('b')
-        self.assertEqual(result[0], ['b', 'a'])
 
     def test_first_error_str(self):
         """FirstErrors have a pleasing format."""

--- a/effect/twisted.py
+++ b/effect/twisted.py
@@ -22,7 +22,7 @@ from twisted.internet.defer import Deferred, gatherResults
 from twisted.python.failure import Failure
 from twisted.internet.task import deferLater
 
-from ._intents import Delay, ParallelEffects
+from ._intents import Delay, ParallelEffects, perform_parallel_async
 from ._base import perform as base_perform
 from ._dispatcher import TypeDispatcher
 from ._utils import wraps
@@ -41,7 +41,7 @@ def make_twisted_dispatcher(reactor):
     with Twisted-specific implementations.
     """
     return TypeDispatcher({
-        ParallelEffects: perform_parallel,
+        ParallelEffects: perform_parallel_async,
         Delay: deferred_performer(partial(perform_delay, reactor)),
     })
 
@@ -76,16 +76,6 @@ def deferred_performer(f):
             else:
                 box.succeed(result)
     return deferred_wrapper
-
-
-@deferred_performer
-def perform_parallel(dispatcher, parallel):
-    """
-    Perform a :obj:`ParallelEffects` intent by using Twisted's
-        :func:`twisted.internet.defer.gatherResults`.
-    """
-    return gatherResults(
-        map(partial(perform, dispatcher), parallel.effects))
 
 
 def perform_delay(reactor, dispatcher, delay):

--- a/effect/twisted.py
+++ b/effect/twisted.py
@@ -22,10 +22,11 @@ from twisted.internet.defer import Deferred
 from twisted.python.failure import Failure
 from twisted.internet.task import deferLater
 
-from ._intents import Delay, ParallelEffects, perform_parallel_async
+from ._intents import Delay, ParallelEffects
 from ._base import perform as base_perform
 from ._dispatcher import TypeDispatcher
 from ._utils import wraps
+from .async import perform_parallel_async
 
 
 def deferred_to_box(d, box):

--- a/effect/twisted.py
+++ b/effect/twisted.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 from functools import partial
 import sys
 
-from twisted.internet.defer import Deferred, gatherResults
+from twisted.internet.defer import Deferred
 from twisted.python.failure import Failure
 from twisted.internet.task import deferLater
 


### PR DESCRIPTION
Thanks to @tomprince for this code; I've modified it slightly:

- FirstError now takes takes only the exception instance instead of the whole exc_info tuple, and calls it `exception` instead of `failure`.
- added a __str__ for FirstError
- Got rid of the ParallelHelper class, replaced it with some nested functions and an itertools.count() object
- The Twisted dispatcher now uses this performer by default
- Tweaked some unit tests, simplifying matching

reviews and testing are greatly appreciated!