### PR TITLE
Add a threaded parallel performer

### DIFF
--- a/docs/source/api/effect.rst
+++ b/docs/source/api/effect.rst
@@ -10,6 +10,7 @@ Submodules
    effect.do
    effect.retry
    effect.testing
+   effect.threads
    effect.twisted
 
 Module contents

--- a/docs/source/api/effect.threads.rst
+++ b/docs/source/api/effect.threads.rst
@@ -1,0 +1,7 @@
+effect.threads module
+=====================
+
+.. automodule:: effect.threads
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/effect/__init__.py
+++ b/effect/__init__.py
@@ -10,7 +10,10 @@ See https://effect.readthedocs.org/ for documentation.
 from __future__ import absolute_import
 
 from ._base import Effect, perform, NoPerformerFoundError
-from ._sync import NotSynchronousError, sync_perform, sync_performer
+from ._sync import (
+    NotSynchronousError,
+    sync_perform,
+    sync_performer)
 from ._intents import (
     Delay, ParallelEffects, parallel,
     Constant, Error, FirstError, Func,

--- a/effect/_test_utils.py
+++ b/effect/_test_utils.py
@@ -1,5 +1,6 @@
 """Another sad little utility module."""
 
+import sys
 import traceback
 
 from characteristic import attributes
@@ -36,3 +37,16 @@ class MatchesReraisedExcInfo(object):
         if not tail_equals(expected[1:], new[1:]):
             return ReraisedTracebackMismatch(expected_tb=expected,
                                              got_tb=new)
+
+
+def get_exc_info(exception):
+    """Get an exc_info tuple based on an exception instance."""
+    try:
+        raise exception
+    except:
+        return sys.exc_info()
+
+
+def raise_(e):
+    """Raise an exception instance. Exists so you can raise in a lambda."""
+    raise e

--- a/effect/test_async.py
+++ b/effect/test_async.py
@@ -1,107 +1,23 @@
 from __future__ import print_function
 
-import sys
-from functools import partial
-
-from characteristic import attributes
-
-import six
-
 from testtools.testcase import TestCase
-from testtools.matchers import Equals, MatchesStructure
 
 from ._base import Effect, perform
 from ._dispatcher import ComposedDispatcher, TypeDispatcher
-from ._intents import (
-    Constant, FirstError, Func, ParallelEffects, base_dispatcher,
-    parallel)
-from ._sync import sync_perform
+from ._intents import ParallelEffects, base_dispatcher, parallel
 from .async import perform_parallel_async
 from .test_base import func_dispatcher
-from ._test_utils import MatchesReraisedExcInfo
+from .test_parallel_performers import ParallelPerformerTestsMixin
 
 
-@attributes(['message'])
-class EquitableException(Exception):
-    pass
-
-
-def get_exc_info(exception):
-    try:
-        raise exception
-    except:
-        return sys.exc_info()
-
-
-class PerformParallelAsyncTests(TestCase):
+class PerformParallelAsyncTests(TestCase, ParallelPerformerTestsMixin):
+    """Tests for :func:`perform_parallel_async`."""
 
     def setUp(self):
         super(PerformParallelAsyncTests, self).setUp()
         self.dispatcher = ComposedDispatcher([
             base_dispatcher,
             TypeDispatcher({ParallelEffects: perform_parallel_async})])
-
-    def test_empty(self):
-        """
-        When given an empty list of effects, ``perform_parallel_async`` returns
-        an empty list synchronusly.
-        """
-        result = sync_perform(
-            self.dispatcher,
-            parallel([]))
-        self.assertEqual(result, [])
-
-    def test_parallel(self):
-        """
-        'parallel' results in a list of results of the given effects, in the
-        same order that they were passed to parallel.
-        """
-        result = sync_perform(
-            self.dispatcher,
-            parallel([Effect(Constant('a')),
-                      Effect(Constant('b'))]))
-        self.assertEqual(result, ['a', 'b'])
-
-    def test_error(self):
-        """
-        When given an effect that results in a Error,
-        ``perform_parallel_async`` result in ``FirstError``.
-        """
-        expected_exc_info = get_exc_info(EquitableException(message='foo'))
-        reraise = partial(six.reraise, *expected_exc_info)
-        try:
-            sync_perform(
-                self.dispatcher,
-                parallel([Effect(Func(reraise))]))
-        except FirstError as fe:
-            self.assertThat(
-                fe,
-                MatchesStructure(
-                    index=Equals(0),
-                    exc_info=MatchesReraisedExcInfo(expected_exc_info)))
-        else:
-            self.fail("sync_perform should have raised FirstError.")
-
-    def test_error_index(self):
-        """
-        The ``index`` of a :obj:`FirstError` is the index of the effect that
-        failed in the list.
-        """
-        expected_exc_info = get_exc_info(EquitableException(message='foo'))
-        reraise = partial(six.reraise, *expected_exc_info)
-        try:
-            sync_perform(
-                self.dispatcher,
-                parallel([
-                    Effect(Constant(1)),
-                    Effect(Func(reraise)),
-                    Effect(Constant(2))]))
-        except FirstError as fe:
-            self.assertThat(
-                fe,
-                MatchesStructure(
-                    index=Equals(1),
-                    exc_info=MatchesReraisedExcInfo(expected_exc_info)))
 
     def test_out_of_order(self):
         """

--- a/effect/test_base.py
+++ b/effect/test_base.py
@@ -6,6 +6,7 @@ from testtools import TestCase
 from testtools.matchers import MatchesException, MatchesListwise
 
 from ._base import Effect, NoPerformerFoundError, perform
+from ._test_utils import raise_
 
 
 def func_dispatcher(intent):
@@ -287,7 +288,3 @@ class EffectPerformTests(TestCase):
         perform(func_dispatcher, eff)
         boxes[0].succeed('foo')
         self.assertEqual(calls[0], calls[1])
-
-
-def raise_(e):
-    raise e

--- a/effect/test_parallel_performers.py
+++ b/effect/test_parallel_performers.py
@@ -1,0 +1,83 @@
+from functools import partial
+
+from characteristic import attributes
+
+import six
+
+from testtools.matchers import MatchesStructure, Equals
+
+from . import Effect
+from ._intents import Constant, Func, FirstError, parallel
+from ._sync import sync_perform
+from ._test_utils import MatchesReraisedExcInfo, get_exc_info
+
+
+@attributes(['message'])
+class EquitableException(Exception):
+    pass
+
+
+class ParallelPerformerTestsMixin(object):
+    """Common tests for any performer of :obj:`effect.ParallelEffects`."""
+
+    def test_empty(self):
+        """
+        When given an empty list of effects, ``perform_parallel_async`` returns
+        an empty list synchronusly.
+        """
+        result = sync_perform(
+            self.dispatcher,
+            parallel([]))
+        self.assertEqual(result, [])
+
+    def test_parallel(self):
+        """
+        'parallel' results in a list of results of the given effects, in the
+        same order that they were passed to parallel.
+        """
+        result = sync_perform(
+            self.dispatcher,
+            parallel([Effect(Constant('a')),
+                      Effect(Constant('b'))]))
+        self.assertEqual(result, ['a', 'b'])
+
+    def test_error(self):
+        """
+        When given an effect that results in a Error,
+        ``perform_parallel_async`` result in ``FirstError``.
+        """
+        expected_exc_info = get_exc_info(EquitableException(message='foo'))
+        reraise = partial(six.reraise, *expected_exc_info)
+        try:
+            sync_perform(
+                self.dispatcher,
+                parallel([Effect(Func(reraise))]))
+        except FirstError as fe:
+            self.assertThat(
+                fe,
+                MatchesStructure(
+                    index=Equals(0),
+                    exc_info=MatchesReraisedExcInfo(expected_exc_info)))
+        else:
+            self.fail("sync_perform should have raised FirstError.")
+
+    def test_error_index(self):
+        """
+        The ``index`` of a :obj:`FirstError` is the index of the effect that
+        failed in the list.
+        """
+        expected_exc_info = get_exc_info(EquitableException(message='foo'))
+        reraise = partial(six.reraise, *expected_exc_info)
+        try:
+            sync_perform(
+                self.dispatcher,
+                parallel([
+                    Effect(Constant(1)),
+                    Effect(Func(reraise)),
+                    Effect(Constant(2))]))
+        except FirstError as fe:
+            self.assertThat(
+                fe,
+                MatchesStructure(
+                    index=Equals(1),
+                    exc_info=MatchesReraisedExcInfo(expected_exc_info)))

--- a/effect/test_sync.py
+++ b/effect/test_sync.py
@@ -1,11 +1,10 @@
 from functools import partial
 
 from testtools import TestCase
-from testtools.matchers import (
-    MatchesException, raises)
+from testtools.matchers import MatchesException, raises
 
-from . import Effect
-from ._sync import sync_perform, NotSynchronousError, sync_performer
+from ._base import Effect
+from ._sync import NotSynchronousError, sync_perform, sync_performer
 
 
 def func_dispatcher(intent):

--- a/effect/test_threads.py
+++ b/effect/test_threads.py
@@ -1,0 +1,24 @@
+from __future__ import print_function
+
+from functools import partial
+
+from multiprocessing.pool import ThreadPool
+
+from testtools import TestCase
+
+from ._intents import ParallelEffects, base_dispatcher
+from ._dispatcher import ComposedDispatcher, TypeDispatcher
+from .threads import perform_parallel_with_pool
+from .test_parallel_performers import ParallelPerformerTestsMixin
+
+
+class ParallelPoolPerformerTests(TestCase, ParallelPerformerTestsMixin):
+    """Tests for :func:`perform_parallel_with_pool`."""
+
+    def setUp(self):
+        super(ParallelPoolPerformerTests, self).setUp()
+        self.pool = ThreadPool()
+        self.p_performer = partial(perform_parallel_with_pool, self.pool)
+        self.dispatcher = ComposedDispatcher([
+            base_dispatcher,
+            TypeDispatcher({ParallelEffects: self.p_performer})])

--- a/effect/threads.py
+++ b/effect/threads.py
@@ -23,11 +23,15 @@ def perform_parallel_with_pool(pool, dispatcher, parallel_effects):
         parallel_performer = functools.partial(
             perform_parallel_effects_with_pool, my_pool)
         dispatcher = TypeDispatcher({ParallelEffects: parallel_performer, ...})
+
+    NOTE: ``ThreadPool`` was broken in Python 3.4.0, but fixed by 3.4.1. This
+    performer should work for any version of Python supported by Effect other
+    than 3.4.0.
     """
 
     # pool.map raises whatever exception is raised first, which is the exact
-    # behavior we want to get this performer -- we just need to translate it to
-    # a FirstError exception.
+    # behavior we want in this performer -- we just need to translate it to a
+    # FirstError exception.
     def perform_child(index_and_effect):
         index, effect = index_and_effect
         try:

--- a/effect/threads.py
+++ b/effect/threads.py
@@ -1,0 +1,40 @@
+import sys
+
+import six
+
+from ._intents import FirstError
+from ._sync import sync_perform, sync_performer
+
+
+@sync_performer
+def perform_parallel_with_pool(pool, dispatcher, parallel_effects):
+    """
+    A performer for :obj:`effect.ParallelEffects` which uses a
+    ``multiprocessing.pool.ThreadPool`` to perform the child effects in
+    parallel.
+
+    Note that this *can't* be used with a ``multiprocessing.Pool``, since
+    you can't pass closures to its ``map`` method.
+
+    This function takes the pool as its first argument, so you'll need to
+    partially apply it when registering it in your dispatcher, like so::
+
+        my_pool = ThreadPool()
+        parallel_performer = functools.partial(
+            perform_parallel_effects_with_pool, my_pool)
+        dispatcher = TypeDispatcher({ParallelEffects: parallel_performer, ...})
+    """
+
+    # pool.map raises whatever exception is raised first, which is the exact
+    # behavior we want to get this performer -- we just need to translate it to
+    # a FirstError exception.
+    def perform_child(index_and_effect):
+        index, effect = index_and_effect
+        try:
+            return sync_perform(dispatcher, effect)
+        except:
+            exc_info = sys.exc_info()
+            six.reraise(FirstError,
+                        FirstError(exc_info=exc_info, index=index),
+                        exc_info[2])
+    return pool.map(perform_child, enumerate(parallel_effects.effects))


### PR DESCRIPTION
This PR adds effect.threads.perform_parallel_with_pool, which can use a multiprocessing.pool.ThreadPool (or, any object with a `map` method that supports similar behavior).

I factored out the tests from the async performer since they can be used directly with the threaded performer.

Amusingly, this code does not work on Python 3.4.0, since it hits bug http://bugs.python.org/issue20980 . But this was fixed at least by 3.4.2, maybe 3.4.1 (I can't tell).