### PR TITLE
add an ERef object, like Haskell's IORef.

### DIFF
--- a/effect/ref.py
+++ b/effect/ref.py
@@ -1,0 +1,60 @@
+from characteristic import attributes
+
+from ._base import Effect
+from ._dispatcher import TypeDispatcher
+from ._sync import sync_performer
+
+
+class ERef(object):
+    """
+    An effectful mutable variable.
+
+    Compare to Haskell's ``IORef`` or Clojure's ``atom``.
+    """
+
+    def __init__(self, initial):
+        self._value = initial
+
+    def read(self):
+        """Return an Effect that results in the current value."""
+        return Effect(ReadERef(eref=self))
+
+    def modify(self, transformer):
+        """
+        Return an Effect that updates the value with ``fn(old_value)``.
+        """
+        return Effect(ModifyERef(eref=self, transformer=transformer))
+
+
+@attributes(['eref'])
+class ReadERef(object):
+    """Intent that gets an ERef value."""
+
+
+@attributes(['eref', 'transformer'])
+class ModifyERef(object):
+    """Intent that modifies an ERef value in-place with a transformer func."""
+
+
+@sync_performer
+def perform_read_eref(dispatcher, intent):
+    """Performer for :obj:`ReadERef`."""
+    return intent.eref._value
+
+
+@sync_performer
+def perform_modify_eref(dispatcher, intent):
+    """
+    Performer for :obj:`ModifyERef`.
+
+    Note that while :obj:`ModifyERef` is designed to allow strong consistency,
+    this performer is _not_ threadsafe, in the sense that it's possible to
+    overwrite unobserved values. This may change in the future.
+    """
+    new_value = intent.transformer(intent.eref._value)
+    intent.eref._value = new_value
+    return new_value
+
+
+eref_dispatcher = TypeDispatcher({ReadERef: perform_read_eref,
+                                  ModifyERef: perform_modify_eref})

--- a/effect/ref.py
+++ b/effect/ref.py
@@ -7,7 +7,9 @@ from ._sync import sync_performer
 
 class ERef(object):
     """
-    An effectful mutable variable.
+    An effectful mutable variable, suitable for sharing between multiple
+    logical threads of execution, that can be read and modified in a purely
+    functional way.
 
     Compare to Haskell's ``IORef`` or Clojure's ``atom``.
     """

--- a/effect/test_ref.py
+++ b/effect/test_ref.py
@@ -3,30 +3,31 @@ from testtools import TestCase
 from ._base import Effect
 from ._sync import sync_perform
 from .ref import (
-    ERef, ModifyERef, ReadERef,
-    eref_dispatcher)
+    Reference, ModifyReference, ReadReference,
+    reference_dispatcher)
 
 
-class ERefTests(TestCase):
-    """Tests for :obj:`ERef`."""
+class ReferenceTests(TestCase):
+    """Tests for :obj:`Reference`."""
 
     def test_read(self):
         """``read`` returns an Effect that represents the current value."""
-        ref = ERef('initial')
-        self.assertEqual(ref.read(), Effect(ReadERef(eref=ref)))
+        ref = Reference('initial')
+        self.assertEqual(ref.read(), Effect(ReadReference(ref=ref)))
 
     def test_modify(self):
         """``modify`` returns an Effect that represents modification."""
-        ref = ERef(0)
+        ref = Reference(0)
         transformer = lambda x: x + 1
         eff = ref.modify(transformer)
         self.assertEqual(eff,
-                         Effect(ModifyERef(eref=ref, transformer=transformer)))
+                         Effect(ModifyReference(ref=ref,
+                                                transformer=transformer)))
 
     def test_perform_read(self):
         """Performing the reading results in the current value."""
-        ref = ERef('initial')
-        result = sync_perform(eref_dispatcher, ref.read())
+        ref = Reference('initial')
+        result = sync_perform(reference_dispatcher, ref.read())
         self.assertEqual(result, 'initial')
 
     def test_perform_modify(self):
@@ -34,8 +35,8 @@ class ERefTests(TestCase):
         Performing the modification results in transforming the current value,
         and also returns the new value.
         """
-        ref = ERef(0)
+        ref = Reference(0)
         transformer = lambda x: x + 1
-        result = sync_perform(eref_dispatcher, ref.modify(transformer))
+        result = sync_perform(reference_dispatcher, ref.modify(transformer))
         self.assertEqual(result, 1)
-        self.assertEqual(sync_perform(eref_dispatcher, ref.read()), 1)
+        self.assertEqual(sync_perform(reference_dispatcher, ref.read()), 1)

--- a/effect/test_ref.py
+++ b/effect/test_ref.py
@@ -1,0 +1,41 @@
+from testtools import TestCase
+
+from ._base import Effect
+from ._sync import sync_perform
+from .ref import (
+    ERef, ModifyERef, ReadERef,
+    eref_dispatcher)
+
+
+class ERefTests(TestCase):
+    """Tests for :obj:`ERef`."""
+
+    def test_read(self):
+        """``read`` returns an Effect that represents the current value."""
+        ref = ERef('initial')
+        self.assertEqual(ref.read(), Effect(ReadERef(eref=ref)))
+
+    def test_modify(self):
+        """``modify`` returns an Effect that represents modification."""
+        ref = ERef(0)
+        transformer = lambda x: x + 1
+        eff = ref.modify(transformer)
+        self.assertEqual(eff,
+                         Effect(ModifyERef(eref=ref, transformer=transformer)))
+
+    def test_perform_read(self):
+        """Performing the reading results in the current value."""
+        ref = ERef('initial')
+        result = sync_perform(eref_dispatcher, ref.read())
+        self.assertEqual(result, 'initial')
+
+    def test_perform_modify(self):
+        """
+        Performing the modification results in transforming the current value,
+        and also returns the new value.
+        """
+        ref = ERef(0)
+        transformer = lambda x: x + 1
+        result = sync_perform(eref_dispatcher, ref.modify(transformer))
+        self.assertEqual(result, 1)
+        self.assertEqual(sync_perform(eref_dispatcher, ref.read()), 1)


### PR DESCRIPTION
It only exposes `read` and `modify` operations for now, and doesn't implement the cool STM-style in-place updates, but the interface allows for it.