### PR TITLE
Sequence dispatcher

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,10 +113,12 @@ but now has contributions from the following people:
 
 .. _`Christopher Armstrong`: https://github.com/radix
 
+- `cyli`_
 - `lvh`_
 - `Manish Tomar`_
 - `Tom Prince`_
 
+.. _`cyli`: https://github.com/cyli
 .. _`lvh`: https://github.com/lvh
 .. _`Manish Tomar`: https://github.com/manishtomar
 .. _`Tom Prince`: https://github.com/tomprince

--- a/effect/test_testing.py
+++ b/effect/test_testing.py
@@ -302,3 +302,8 @@ class SequenceDispatcherTests(TestCase):
         self.assertEqual(
             sync_perform(d, eff),
             (('performfoo', 'foo'), ('performbar', 'bar')))
+
+    def test_ran_out(self):
+        """When there are no more items left, None is returned."""
+        d = SequenceDispatcher([])
+        self.assertEqual(d('foo'), None)

--- a/effect/test_testing.py
+++ b/effect/test_testing.py
@@ -18,7 +18,6 @@ from .testing import (
     ESFunc,
     EQDispatcher,
     EQFDispatcher,
-    IntentMismatchError,
     SequenceDispatcher,
     fail_effect,
     resolve_effect,
@@ -285,13 +284,10 @@ class SequenceDispatcherTests(TestCase):
 
     def test_mismatch(self):
         """
-        When an intent isn't expected, a :obj:`IntentMismatchError` is raised.
+        When an intent isn't expected, a :obj:`None` is returned.
         """
         d = SequenceDispatcher([('foo', lambda i: 1 / 0)])
-        e = self.assertRaises(IntentMismatchError,
-                              lambda: sync_perform(d, Effect('hello')))
-        self.assertEqual(e.expected_intent, 'foo')
-        self.assertEqual(e.got_intent, 'hello')
+        self.assertEqual(d('hello'), None)
 
     def test_success(self):
         """

--- a/effect/test_testing.py
+++ b/effect/test_testing.py
@@ -288,7 +288,8 @@ class SequenceDispatcherTests(TestCase):
         When an intent isn't expected, a :obj:`IntentMismatchError` is raised.
         """
         d = SequenceDispatcher([('foo', lambda i: 1 / 0)])
-        e = self.assertRaises(IntentMismatchError, lambda: sync_perform(d, Effect('hello')))
+        e = self.assertRaises(IntentMismatchError,
+                              lambda: sync_perform(d, Effect('hello')))
         self.assertEqual(e.expected_intent, 'foo')
         self.assertEqual(e.got_intent, 'hello')
 

--- a/effect/test_testing.py
+++ b/effect/test_testing.py
@@ -284,7 +284,7 @@ class SequenceDispatcherTests(TestCase):
 
     def test_mismatch(self):
         """
-        When an intent isn't expected, a :obj:`None` is returned.
+        When an intent isn't expected, a None is returned.
         """
         d = SequenceDispatcher([('foo', lambda i: 1 / 0)])
         self.assertEqual(d('hello'), None)
@@ -306,4 +306,12 @@ class SequenceDispatcherTests(TestCase):
     def test_ran_out(self):
         """When there are no more items left, None is returned."""
         d = SequenceDispatcher([])
+        self.assertEqual(d('foo'), None)
+
+    def test_out_of_order(self):
+        """Order of items in the sequence matters."""
+        d = SequenceDispatcher([
+            ('bar', lambda i: ('performbar', i)),
+            ('foo', lambda i: ('performfoo', i)),
+        ])
         self.assertEqual(d('foo'), None)

--- a/effect/testing.py
+++ b/effect/testing.py
@@ -258,6 +258,10 @@ class SequenceDispatcher(object):
             (MyIntent('a'), lambda i: 'my-intent-result'),
             (OtherIntent('b'), lambda i: 'other-intent-result')
         ])
+
+    :obj:`None` is returned if the next intent in the sequence is not equal to
+    the intent being performed, or if there are no more items left in the
+    sequence.
     """
     def __init__(self, sequence):
         """:param list sequence: Sequence of (intent, fn)."""

--- a/effect/testing.py
+++ b/effect/testing.py
@@ -243,3 +243,43 @@ class EQFDispatcher(object):
         for k, v in self.mapping:
             if k == intent:
                 return sync_performer(lambda d, i: v(i))
+
+
+
+class IntentMismatchError(Exception):
+    def __init__(self, expected_intent, got_intent):
+        self.expected_intent = expected_intent
+        self.got_intent = got_intent
+        super(IntentMismatchError, self).__init__(
+            'Expected intent %r, got %r' % (expected_intent, got_intent))
+
+
+class SequenceDispatcher(object):
+    """
+    A dispatcher which steps through a sequence of (intent, func) tuples and
+    runs ``func`` to perform intents in strict sequence.
+
+    So, if you expect to first perform an intent like ``MyIntent('a')`` and
+    then an intent like ``OtherIntent('b')``, you can create a dispatcher like
+    this::
+
+        SequenceDispatcher([
+            (MyIntent('a'), lambda i: 'my-intent-result'),
+            (OtherIntent('b'), lambda i: 'other-intent-result')
+        ])
+
+    Unlike most dispatchers, this one raises an exception
+    (:obj:`IntentMismatchError`) when an intent is not found, in the order
+    expected.
+    """
+    def __init__(self, sequence):
+        """:param list sequence: Sequence of (intent, fn)."""
+        self.sequence = sequence
+
+    def __call__(self, intent):
+        exp_intent, func = self.sequence[0]
+        if intent == exp_intent:
+            self.sequence = self.sequence[1:]
+            return sync_performer(lambda d, i: func(i))
+        else:
+            raise IntentMismatchError(exp_intent, intent)

--- a/effect/testing.py
+++ b/effect/testing.py
@@ -264,6 +264,8 @@ class SequenceDispatcher(object):
         self.sequence = sequence
 
     def __call__(self, intent):
+        if len(self.sequence) == 0:
+            return
         exp_intent, func = self.sequence[0]
         if intent == exp_intent:
             self.sequence = self.sequence[1:]

--- a/effect/testing.py
+++ b/effect/testing.py
@@ -245,7 +245,6 @@ class EQFDispatcher(object):
                 return sync_performer(lambda d, i: v(i))
 
 
-
 class IntentMismatchError(Exception):
     def __init__(self, expected_intent, got_intent):
         self.expected_intent = expected_intent

--- a/effect/testing.py
+++ b/effect/testing.py
@@ -245,14 +245,6 @@ class EQFDispatcher(object):
                 return sync_performer(lambda d, i: v(i))
 
 
-class IntentMismatchError(Exception):
-    def __init__(self, expected_intent, got_intent):
-        self.expected_intent = expected_intent
-        self.got_intent = got_intent
-        super(IntentMismatchError, self).__init__(
-            'Expected intent %r, got %r' % (expected_intent, got_intent))
-
-
 class SequenceDispatcher(object):
     """
     A dispatcher which steps through a sequence of (intent, func) tuples and
@@ -266,10 +258,6 @@ class SequenceDispatcher(object):
             (MyIntent('a'), lambda i: 'my-intent-result'),
             (OtherIntent('b'), lambda i: 'other-intent-result')
         ])
-
-    Unlike most dispatchers, this one raises an exception
-    (:obj:`IntentMismatchError`) when an intent is not found, in the order
-    expected.
     """
     def __init__(self, sequence):
         """:param list sequence: Sequence of (intent, fn)."""
@@ -280,5 +268,3 @@ class SequenceDispatcher(object):
         if intent == exp_intent:
             self.sequence = self.sequence[1:]
             return sync_performer(lambda d, i: func(i))
-        else:
-            raise IntentMismatchError(exp_intent, intent)


### PR DESCRIPTION
Add a `SequenceDispatcher` dispatcher, which is similar to EQFDispatcher, except that it requires the inputs to be in the order that the intents are actually performed.

This allows meaningful testing of code that performs equal intents multiple times, when the order and sequencing of intents matters.